### PR TITLE
Fix bug when setting n_agents or n_objects to 0

### DIFF
--- a/vivarium/controllers/converters.py
+++ b/vivarium/controllers/converters.py
@@ -218,7 +218,7 @@ def set_state_from_config_dict(config_dict, state=None):
     state = state or get_default_state(n_entities_dict)
     e_idx = jnp.zeros(sum(n_entities_dict.values()), dtype=int)
     for stype, configs in config_dict.items():
-        params = configs[0].param_names()
+        params = configs[0].param_names() if len(configs) > 0 else []
         for p in params:
             state_field_info = configs_to_state_dict[stype][p]
             nve_idx = [c.idx for c in configs] if state_field_info.nested_field[0] == 'nve_state' else range(len(configs))
@@ -248,6 +248,8 @@ def set_configs_from_state(state, config_dict=None):
             for f in state_field_info.nested_field:
                 value = getattr(value, f)
             for config in config_dict[stype]:
+                if config is None:
+                    continue
                 t = type(getattr(config, param))
                 row_idx = state.row_idx(state_field_info.nested_field[0], config.idx)
                 if state_field_info.column_idx is None:

--- a/vivarium/controllers/panel_controller.py
+++ b/vivarium/controllers/panel_controller.py
@@ -44,6 +44,9 @@ class Selected(param.Parameterized):
 
     def selection_nve_idx(self, nve_idx):
         return nve_idx[np.array(self.selection)].tolist()
+    
+    def __len__(self):
+        return len(self.selection)
 
 
 class PanelController(SimulatorController):
@@ -57,6 +60,7 @@ class PanelController(SimulatorController):
         self.panel_configs = {stype: [stype_to_panel_config[stype]() for _ in range(len(configs))]
                               for stype, configs in self.configs.items()}
         self.selected_panel_configs = {EntityType.AGENT: PanelAgentConfig(), EntityType.OBJECT: PanelObjectConfig()}
+        self.pull_selected_panel_configs()
         self.panel_simulator_config = PanelSimulatorConfig()
 
         self.update_entity_list()

--- a/vivarium/interface/panel_app.py
+++ b/vivarium/interface/panel_app.py
@@ -37,7 +37,7 @@ class EntityManager:
                                  onlychanged=True, precedence=0)
         for i, pc in enumerate(self.panel_configs):
             pc.param.watch(self.update_cds_view, pc.param_names(), onlychanged=True)
-            self.config[i].param.watch(self.hide_non_existing, "exists", onlychanged=False)
+            self.config[i].param.watch(self.hide_non_existing, "exists", onlychanged=True)
 
     def drag_cb(self, attr, old, new):
         for i, c in enumerate(self.config):
@@ -68,7 +68,7 @@ class EntityManager:
 
     def update_cds_view(self, event):
         n = event.name
-        for attr in [n] if n != "visible" else self.panel_configs[0].param_names():
+        for attr in [n] if n != "visible" else (self.panel_configs[0].param_names() if len(self.panel_configs) else []):
             f = [getattr(pc, attr) and pc.visible for pc in self.panel_configs]
             self.cds_view[attr].filter = BooleanFilter(f)
 
@@ -273,16 +273,16 @@ class WindowManager(Parameterized):
         self.config_columns = pn.Row(*
             [pn.Column(
                 pn.pane.Markdown("### SIMULATOR", align="center"),
-                pn.panel(self.controller.panel_simulator_config, name="Visualization configurations"),
+                pn.panel(self.controller.panel_simulator_config, name="Visualization configuration"),
                 pn.panel(self.controller.simulator_config, name="Configurations"),
                 visible=False, sizing_mode="scale_height", scroll=True)] +
             [pn.Column(
                 pn.pane.Markdown(f"### {etype.name}", align="center"),
                 self.controller.selected_entities[etype],
-                pn.panel(self.controller.selected_panel_configs[etype], name="Visualization configurations"),
-                pn.panel(self.controller.selected_configs[etype], name="State configurations"),
+                pn.panel(self.controller.selected_panel_configs[etype], name="Visualization configuration"),
+                pn.panel(self.controller.selected_configs[etype], name="State configuration"),
                 visible=True, sizing_mode="scale_height", scroll=True)
-            for etype in EntityType])
+            for etype in self.entity_managers.keys()])
 
         app = pn.Row(pn.Column(pn.Row(pn.pane.Markdown("### Start/Stop server", align="center"),
                                       self.start_toggle),

--- a/vivarium/interface/panel_app.py
+++ b/vivarium/interface/panel_app.py
@@ -233,8 +233,9 @@ class WindowManager(Parameterized):
 
 
     def entity_toggle_cb(self, event):
-        for i, t in enumerate(self.config_types):
-            self.config_columns[i].visible = t in event.new
+        self.config_columns[0].visible = "SIMULATOR" in event.new
+        for i, t in enumerate(self.entity_managers.keys()):
+            self.config_columns[i].visible = t.name in event.new
 
     def update_timestep_cb(self, event):
         self.pcb_plot.period = event.new


### PR DESCRIPTION
## Description
I went down the rabbit hole to try fixing #53 . I'm not sure it is the best solution but it seems to work, please have a look. @Marsolo1 Can you change the panel app so that it does not display the config types with 0 entities in the interface? (both in "Show configurations" as well as the "Selected", "Visualization configurations' and "State configurations". You can also take the occasion to remove the "s" in the two last ones). Let me know if not possible, in that case we will need to also take into account what to do if the Visualization configuration is modified (for now it breaks).

## Related Issue (if applicable)
#53 
## How to Test
Launch the server **(try with both `--n_agents 0` and `--n_objects 0`)**
```
python3 scripts/run_server.py
```
Launch the Panel interface
```
panel serve scripts/run_interface.py --autoreload
```

Check that everything works as expected (please do it extensively to be sure I haven't introduced a new bug). You can also check the changes in the code in case you see something that might cause future issues.

## Screenshots (if applicable)
<!--- Provide screenshots to demonstrate the changes visually, if applicable -->
