### PR TITLE
Add automatic generation of default config yaml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,19 @@ You will find explanations of the web interface and how to control the simulator
 
 ## Development
 
-### grpc
+### Default scene generation
 
+If you wish to make changes to the state of the simulation and change the init functions in `vivarium/simulator/states.py`, 
+you can automatically generate a default yaml config file from the default parameters of the functions. 
+
+To do so, just run : 
+
+```bash
+python3 scripts/generate_default_config.py 
+```
+
+
+### grpc
 
 grpc compilation command line (normally only needed if modifying the .proto file for communication between server and controllers, e.g. the web interface):
 

--- a/conf/scene/default.yaml
+++ b/conf/scene/default.yaml
@@ -1,36 +1,36 @@
-simulator:
-  max_agents: 10
-  max_objects: 2
-  box_size: 100.0
-  num_steps_lax: 4
-  dt: 0.1
-  freq: 40
-  neighbor_radius: 100.0
-  to_jit: True
-  use_fori_loop: False
-  collision_eps: 0.1
-  collision_alpha: 0.5
-
-entities:
-  diameter: 5.
-  friction: 0.1
-  mass_center: 1.
-  mass_orientation: 0.125
-  agents_positions:
-  objects_positions:
-  existing_agents:
-  existing_objects:
-  seed: 42
-
 agents:
   behavior: 1
-  wheel_diameter: 2.
-  speed_mul: 1.
-  max_speed: 10.
-  theta_mul: 1.
-  prox_dist_max: 40.
-  prox_cos_min: 0.
-  color: "blue"
+  color: blue
+  max_speed: 10.0
+  prox_cos_min: 0.0
+  prox_dist_max: 40.0
+  speed_mul: 1.0
+  theta_mul: 1.0
+  wheel_diameter: 2.0
+
+entities:
+  agents_positions: null
+  diameter: 5.0
+  existing_agents: null
+  existing_objects: null
+  friction: 0.1
+  mass_center: 1.0
+  mass_orientation: 0.125
+  objects_positions: null
+  seed: 0
 
 objects:
-  color: "red"
+  color: red
+
+simulator:
+  box_size: 100.0
+  collision_alpha: 0.5
+  collision_eps: 0.1
+  dt: 0.1
+  freq: 40.0
+  max_agents: 10
+  max_objects: 2
+  neighbor_radius: 100.0
+  num_steps_lax: 4
+  to_jit: true
+  use_fori_loop: false

--- a/scripts/generate_default_config.py
+++ b/scripts/generate_default_config.py
@@ -1,0 +1,4 @@
+# Run this script to automatically generate a default yaml file from init functions in states.py
+from vivarium.simulator.states import generate_default_config_files
+
+generate_default_config_files()


### PR DESCRIPTION
## Description
<!--- Provide a brief summary of the changes in this pull request -->

Add automatic generation of default config yaml file from the init functions parameters in states.py

The only thing to potentially improve is the order of the parameters in the file (here sorted alphabetically). This is due to the fact I use a python dict (unordered) to generate the yaml file. 

## How to Test
Launch the server with default config
```
python3 scripts/run_server.py
```
Launch the Panel interface
```
panel serve scripts/run_interface.py --autoreload
```
<!--- Describe the steps to test the changes made in this pull request -->
