### PR TITLE
[WIP] Corentin/prototype selective sensors

### DIFF
--- a/conf/scene/debug.yaml
+++ b/conf/scene/debug.yaml
@@ -1,0 +1,7 @@
+entities:
+  existing_agents: 5
+  existing_objects: 1
+
+simulator:
+  to_jit: false
+  use_fori_loop: false

--- a/conf/scene/pr_test.yaml
+++ b/conf/scene/pr_test.yaml
@@ -1,0 +1,7 @@
+entities:
+  existing_agents: 8
+  existing_objects: 1
+
+agents:
+  color: ['red', 'red', 'red', 'blue', 'blue', 'blue', 'blue', 'blue', 'black', 'black']
+  prox_dist_max: 100.

--- a/vivarium/simulator/physics_engine.py
+++ b/vivarium/simulator/physics_engine.py
@@ -299,8 +299,6 @@ def dynamics_rigid(displacement, shift, behavior_bank, force_fn=None):
 
     def step_fn(state, neighbor, agent_neighs_idx):
         exists_mask = (state.entities_state.exists == 1)  # Only existing entities have effect on others
-        print('step fn')
-        print(f"{exists_mask.shape = }")
         state = state.set(agent_state=compute_prox(state, agent_neighs_idx, target_exists_mask=exists_mask))
         state = state.set(agent_state=sensorimotor(state.agent_state))
         force = force_fn(state, neighbor, exists_mask)

--- a/vivarium/simulator/states.py
+++ b/vivarium/simulator/states.py
@@ -139,8 +139,12 @@ class State:
 
 
 # Helper function to transform a color string into rgb with matplotlib colors
-def _string_to_rgb(color_str):
-    return jnp.array(list(mcolors.to_rgb(color_str)))
+# TODO : Maybe change the color of the function but not important atm
+def _string_to_rgb_list(color_str):
+    if isinstance(color_str, str):
+        return list(mcolors.to_rgb(color_str))
+    else:
+        return [list(mcolors.to_rgb(color)) for color in color_str]
 
 
 def init_simulator_state(
@@ -258,12 +262,14 @@ def init_agent_state(
         theta_mul: float = 1.,
         prox_dist_max: float = 40.,
         prox_cos_min: float = 0.,
-        color: str = "blue"
+        color: Optional[Union[str, List[str]]] = "blue"
         ) -> AgentState:
     """
     Initialize agent state with given parameters
     """
     max_agents = simulator_state.max_agents[0]
+    rgb_color = _string_to_rgb_list(color)
+    color = jnp.array(rgb_color) if not isinstance(color, list) else jnp.tile(jnp.array(rgb_color), (max_agents, 1))
 
     return AgentState(
         nve_idx=jnp.arange(max_agents, dtype=int),
@@ -276,8 +282,8 @@ def init_agent_state(
         theta_mul=jnp.full((max_agents), theta_mul),
         proxs_dist_max=jnp.full((max_agents), prox_dist_max),
         proxs_cos_min=jnp.full((max_agents), prox_cos_min),
-        color=jnp.tile(_string_to_rgb(color), (max_agents, 1))
-    )
+        color=color
+        )
 
 
 def init_object_state(
@@ -292,7 +298,7 @@ def init_object_state(
     objects_nve_idx = jnp.arange(start_idx, stop_idx, dtype=int)
     return  ObjectState(
         nve_idx=objects_nve_idx,
-        color=jnp.tile(_string_to_rgb(color), (max_objects, 1))
+        color=jnp.tile(jnp.array(_string_to_rgb_list(color)), (max_objects, 1))
     )
 
 

--- a/vivarium/simulator/states.py
+++ b/vivarium/simulator/states.py
@@ -269,7 +269,7 @@ def init_agent_state(
     """
     max_agents = simulator_state.max_agents[0]
     rgb_color = _string_to_rgb_list(color)
-    color = jnp.array(rgb_color) if not isinstance(color, list) else jnp.tile(jnp.array(rgb_color), (max_agents, 1))
+    color = jnp.array(rgb_color) if not isinstance(color, str) else jnp.tile(jnp.array(rgb_color), (max_agents, 1))
 
     return AgentState(
         nve_idx=jnp.arange(max_agents, dtype=int),


### PR DESCRIPTION
## Description
Did this PR to prototype how we can implement selective sensors. Here I hard-coded the fact that the agents only perceive entities with red color. This is not meant to stay but just a quick way of testing this mechanism. 

I created a config file to test the PR and verify that the agents are only perceiving red entities that exist. 

Even if it is not meant to be merged, can you check it @clement-moulin-frier ? 

## Related Issue (if applicable)
#66 

## How to Test
Launch the server with the testing scene (or modify the color of entities yourself with another initial scene)
```
python3 scripts/run_server.py scene=pr_test
```
Launch the Panel interface
```
panel serve scripts/run_interface.py --autoreload
```

You can also manually change the colors of some entities from the interface (make sure to select the default red value if you want an entity to be perceived, here the agents only see the color [1., 0., 0.] in RGB.
