### PR TITLE
Add test for start/stop server and interface

### DIFF
--- a/tests/test_start_stop_scripts.py
+++ b/tests/test_start_stop_scripts.py
@@ -1,0 +1,26 @@
+import time
+
+import pytest
+
+from vivarium.utils.handle_server_interface import start_server_and_interface, stop_server_and_interface
+
+WAIT_TIME = 0
+
+@pytest.fixture
+def start_and_stop_server():
+    def _start_and_stop(scene_name, notebook_mode):
+        start_server_and_interface(scene_name=scene_name, notebook_mode=notebook_mode, wait_time=WAIT_TIME)
+        time.sleep(1)
+        yield
+        stop_server_and_interface()
+    return _start_and_stop
+
+def test_start_stop(start_and_stop_server):
+    scene_name = "quickstart"
+    start_and_stop_server(scene_name, False)
+    assert True
+
+def test_start_stop_notebook_mode(start_and_stop_server):
+    scene_name = "session_3"
+    start_and_stop_server(scene_name, True)
+    assert True

--- a/vivarium/utils/handle_server_interface.py
+++ b/vivarium/utils/handle_server_interface.py
@@ -32,7 +32,7 @@ def kill_process(pid):
     os.kill(int(pid), signal.SIGTERM)
 
 # Define parameters of the simulator
-def start_server_and_interface(scene_name: str, notebook_mode: bool = True):
+def start_server_and_interface(scene_name: str, notebook_mode: bool = True, wait_time: int = 6):
     """Start the server and interface for the given scene
 
     :param scene_name: scene name
@@ -56,7 +56,7 @@ def start_server_and_interface(scene_name: str, notebook_mode: bool = True):
     print("STARTING SERVER")
     server_process = multiprocessing.Process(target=start_server_process)
     server_process.start()
-    time.sleep(5)
+    time.sleep(wait_time)
 
     interface_command = [
         "panel", 
@@ -69,7 +69,6 @@ def start_server_and_interface(scene_name: str, notebook_mode: bool = True):
     def start_interface_process():
         subprocess.run(interface_command)
 
-    time.sleep(2)
     # start the interface 
     print("\nSTARTING INTERFACE")
     interface_process = multiprocessing.Process(target=start_interface_process)


### PR DESCRIPTION
## Description
<!--- Provide a brief summary of the changes in this pull request -->

- Add waiting time parameter for start server and interface function
- Add automated tests for starting and stopping the server with or without notebook mode